### PR TITLE
Small Change for exacter focus the right inner-element in dropdown menus

### DIFF
--- a/plugins/js/bootstrap-accessibility.js
+++ b/plugins/js/bootstrap-accessibility.js
@@ -86,7 +86,7 @@
       $toggle.attr('aria-expanded','true')
 
       setTimeout(function(){
-            firstItem = $('[role=menuitem]:visible', $par)[0]
+            firstItem = $('.dropdown-menu [role=menuitem]:visible', $par)[0]
             try{ firstItem.focus()} catch(ex) {}
       }, focusDelay)
     })


### PR DESCRIPTION
When using drop-down-menus with more than one hierarchy, the drop-down-item itself can be from type a role="menuitem". I specified the search-string, so that it works in these cases too.
