### PR TITLE
Added missing "return this" to hide()

### DIFF
--- a/plugins/js/bootstrap-accessibility.js
+++ b/plugins/js/bootstrap-accessibility.js
@@ -46,6 +46,7 @@
     $.fn.tooltip.Constructor.prototype.hide = function () {
         hideTooltip.apply(this, arguments)
         removeMultiValAttributes(this.$element, 'aria-describedby', this.tip().attr('id'))
+        return this
     }
 
   // Popover Extension


### PR DESCRIPTION
Latest bootstrap version relies on that. Otherwise you get runtime errors.
