### PR TITLE
Use data-target attribute if present (Collapse extension)

### DIFF
--- a/plugins/js/bootstrap-accessibility.js
+++ b/plugins/js/bootstrap-accessibility.js
@@ -212,7 +212,7 @@
       $colltabs.attr({ 'role':'tab', 'aria-selected':'false', 'aria-expanded':'false' })
       $colltabs.each(function( index ) {
         var colltab = $(this)
-        , collpanel = $(colltab.attr('href'))
+        , collpanel = (colltab.attr('data-target')) ? $(colltab.attr('data-target')) : $(colltab.attr('href'))
         , parent  = colltab.attr('data-parent')
         , collparent = parent && $(parent)
         , collid = colltab.attr('id') || uniqueId('ui-collapse')


### PR DESCRIPTION
This patch fixes a JS error when the element with the attribute data-toggle="collapse" has a URL href (instead of a jQuery selector) and additionally a data-target attribute with the jQuery selector for the collapsible element. This is useful if you want to offer the opportunity to open the link in a new window (or even when JS is disabled).
Example: 
<a data-toggle="collapse" href="http://www.example.org/" data-target="#collapsibleElement>
  Collapsible Group Item #1
</a>
