### PR TITLE
Added missing return this to hide() for popover

### DIFF
--- a/src/js/popover.js
+++ b/src/js/popover.js
@@ -2,7 +2,7 @@
   // ===============================
   
   var showPopover =   $.fn.popover.Constructor.prototype.setContent
-      , hideTPopover =   $.fn.popover.Constructor.prototype.hide
+      , hidePopover =   $.fn.popover.Constructor.prototype.hide
 
     $.fn.popover.Constructor.prototype.setContent = function(){
       showPopover.apply(this, arguments)
@@ -13,7 +13,7 @@
       this.$element.focus()
     }
     $.fn.popover.Constructor.prototype.hide =  function(){
-        hideTPopover.apply(this, arguments)
+        hidePopover.apply(this, arguments)
         removeMultiValAttributes(this.$element, 'aria-describedby', this.tip().attr('id'))
-		return this
+        return this
     }


### PR DESCRIPTION
This is the same as issue #26, but for popover instead of tooltip.

Also fixed a bug where the hidefunction for Tooltip was used instead of
the one for popover.

Tested in Chrome only.
