### PR TITLE
Fix heading levels on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,18 +59,18 @@ Bootstrap Accessibility
 
 <p>This plugin provides enhancements to the Bootstrap 3 components in two areas: keyboard navigation and  screen reader compatibility. There are also minor changes to improve color contrast in alert messages.</p>
 
-<h2>
-<a name="keyboard-navigation" class="anchor" href="#keyboard-navigation"><span class="octicon octicon-link"></span></a>Keyboard Navigation</h2>
+<h3>
+<a name="keyboard-navigation" class="anchor" href="#keyboard-navigation"><span class="octicon octicon-link"></span></a>Keyboard Navigation</h3>
 
 <p>For some widgets, like tab panel, carousel, drop-down menu, etc, the onKeyDown event is employed in various places in order to make the desktop-style keyboard navigation possible. This enables someone who does not or cannot use the mouse navigate those components using tab and arrow keys. To further enhance the seamless navigation for keyboard users the plugin manages keyboard focus wherever appropriate.</p>
 
-<h2>
-<a name="compatibility-with-screen-readers" class="anchor" href="#compatibility-with-screen-readers"><span class="octicon octicon-link"></span></a>Compatibility With Screen Readers</h2>
+<h3>
+<a name="compatibility-with-screen-readers" class="anchor" href="#compatibility-with-screen-readers"><span class="octicon octicon-link"></span></a>Compatibility With Screen Readers</h3>
 
 <p>Once the plugin is loaded into your page, it will search for any available Bootstrap components and, if found, append the necessary <a href="http://www.w3.org/TR/wai-aria/">ARIA roles and states</a> to provide the enhanced semantics to those widgets. This is primarily useful for screen readers. Without ARIA mark-up it is difficult for this technology to express the meaning of dynamic elements, such as modeless alerts, tab panels, popup menus, carousels, etc, to users who cannot see the screen.</p>
 
-<h2>
-<a name="color-contrast" class="anchor" href="#color-contrast"><span class="octicon octicon-link"></span></a>Color Contrast</h2>
+<h3>
+<a name="color-contrast" class="anchor" href="#color-contrast"><span class="octicon octicon-link"></span></a>Color Contrast</h3>
 
 <p>We found that the foreground-to-background color contrast ratio for a Bootstrap alert message is too low. To make it easier for users to read, the color contrast has been increased.</p>
 


### PR DESCRIPTION
This is a change for the [project website’s index page](https://paypal.github.io/bootstrap-accessibility-plugin/). I changed subheadings from `<h2>`s to `<h3>`s.

The page after this change:

![zoomed-out screenshot of page after](https://cloud.githubusercontent.com/assets/79168/8692761/36d31206-2a9f-11e5-8e54-ad1cbdec4957.png)

Before this change:

![zoomed-out screenshot of page before](https://cloud.githubusercontent.com/assets/79168/8692759/32b48eac-2a9f-11e5-9216-4812b830748f.png)