### PR TITLE
Move grunt packages to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,12 @@
   "main": "Gruntfile.js",
   "homepage": "https://github.com/paypal/bootstrap-accessibility-plugin",
   "author": "PayPal Accessibility Team",
-  "dependencies": {
+  "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.4",
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-contrib-concat": "0.4.0",
     "grunt-contrib-compass": "0.8.0"
-  },
-  "devDependencies": {
-    "grunt-contrib-compass": "^0.8.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
That way, they won't be unnecessarily downloaded when doing a `npm install` as a end user.