### PR TITLE
Allow tab access to accordion with no tabs open by default

### DIFF
--- a/src/js/collapse.js
+++ b/src/js/collapse.js
@@ -11,7 +11,7 @@
         , collid = colltab.attr('id') || uniqueId('ui-collapse')
         , parentpanel = collpanel.parent() // panel containing title and panel body
         , parentfirstchild = (collparent) ? collparent.find('.panel.panel-default:first-child') : null // first child of containing accordion
-        , hasopenpanel = collparent.find('.panel-collapse.in').length > 0 // true, if collapse parent has any panels with class 'in'; otherwise, false
+        , hasopenpanel = (collparent) ? collparent.find('.panel-collapse.in').length > 0 : false // true, if collapse parent has any panels with class 'in'; otherwise, false
 
           colltab.attr('id', collid)
 

--- a/src/js/collapse.js
+++ b/src/js/collapse.js
@@ -21,7 +21,10 @@
             collparent.attr({ 'role' : 'tablist', 'aria-multiselectable' : 'true' })
             collpanel.attr({ 'role':'tabpanel', 'aria-labelledby':collid })
 
-            if(collpanel.hasClass('in')){
+            if(!hasopenpanel && parentpanel.is(parentfirstchild)) {
+              colltab.attr({ 'tabindex':'0' })
+              collpanel.attr({ 'tabindex':'-1' })
+            }else if(collpanel.hasClass('in')){
               colltab.attr({ 'aria-selected':'true', 'aria-expanded':'true', 'tabindex':'0' })
               collpanel.attr({ 'tabindex':'0', 'aria-hidden':'false' })
             }else{

--- a/src/js/collapse.js
+++ b/src/js/collapse.js
@@ -9,6 +9,8 @@
         , parent  = colltab.attr('data-parent')
         , collparent = parent && $(parent)
         , collid = colltab.attr('id') || uniqueId('ui-collapse')
+        , parentpanel = collpanel.parent() // panel containing title and panel body
+        , parentfirstchild = (collparent) ? collparent.find('.panel.panel-default:first-child') : null // first child of containing accordion
 
           colltab.attr('id', collid)
 

--- a/src/js/collapse.js
+++ b/src/js/collapse.js
@@ -11,6 +11,7 @@
         , collid = colltab.attr('id') || uniqueId('ui-collapse')
         , parentpanel = collpanel.parent() // panel containing title and panel body
         , parentfirstchild = (collparent) ? collparent.find('.panel.panel-default:first-child') : null // first child of containing accordion
+        , hasopenpanel = collparent.find('.panel-collapse.in').length > 0 // true, if collapse parent has any panels with class 'in'; otherwise, false
 
           colltab.attr('id', collid)
 

--- a/src/js/collapse.js
+++ b/src/js/collapse.js
@@ -16,15 +16,15 @@
           colltab.attr('id', collid)
 
           if(collparent){
-            colltab.attr({ 'role':'tab', 'aria-selected':'false', 'aria-expanded':'false' })
+            colltab.attr({ 'aria-controls': collpanel.attr('id'), 'role':'tab', 'aria-selected':'false', 'aria-expanded':'false' })
             $(collparent).find('div:not(.collapse,.panel-body), h4').attr('role','presentation')
             collparent.attr({ 'role' : 'tablist', 'aria-multiselectable' : 'true' })
 
             if(collpanel.hasClass('in')){
-              colltab.attr({ 'aria-controls': collpanel.attr('id'), 'aria-selected':'true', 'aria-expanded':'true', 'tabindex':'0' })
+              colltab.attr({ 'aria-selected':'true', 'aria-expanded':'true', 'tabindex':'0' })
               collpanel.attr({ 'role':'tabpanel', 'tabindex':'0', 'aria-labelledby':collid, 'aria-hidden':'false' })
             }else{
-              colltab.attr({'aria-controls' : collpanel.attr('id'), 'tabindex':'-1' })
+              colltab.attr({ 'tabindex':'-1' })
               collpanel.attr({ 'role':'tabpanel', 'tabindex':'-1', 'aria-labelledby':collid, 'aria-hidden':'true' })
             }
           }

--- a/src/js/collapse.js
+++ b/src/js/collapse.js
@@ -19,13 +19,14 @@
             colltab.attr({ 'aria-controls': collpanel.attr('id'), 'role':'tab', 'aria-selected':'false', 'aria-expanded':'false' })
             $(collparent).find('div:not(.collapse,.panel-body), h4').attr('role','presentation')
             collparent.attr({ 'role' : 'tablist', 'aria-multiselectable' : 'true' })
+            collpanel.attr({ 'role':'tabpanel', 'aria-labelledby':collid })
 
             if(collpanel.hasClass('in')){
               colltab.attr({ 'aria-selected':'true', 'aria-expanded':'true', 'tabindex':'0' })
-              collpanel.attr({ 'role':'tabpanel', 'tabindex':'0', 'aria-labelledby':collid, 'aria-hidden':'false' })
+              collpanel.attr({ 'tabindex':'0', 'aria-hidden':'false' })
             }else{
               colltab.attr({ 'tabindex':'-1' })
-              collpanel.attr({ 'role':'tabpanel', 'tabindex':'-1', 'aria-labelledby':collid, 'aria-hidden':'true' })
+              collpanel.attr({ 'tabindex':'-1', 'aria-hidden':'true' })
             }
           }
       })


### PR DESCRIPTION
At the moment, accordions that do not have a panel open by default are inaccessible via keyboard navigation using the Tab key. These changes add an additional check to the collapse tab initialization that adds a ```tabindex="1"``` property to the first child panel toggle of an accordion if no other child panel is open by default (i.e. has the "in" class).

To do this, it checks to see if the accordion container has any children with both the "panel-collapse" and "in" classes. If it doesn't, it adds a ```tabindex="0"``` to the first child panel toggle of the accordion container and a ```tabindex="-1"``` to the corresponding child panel.

This has been tested on the following:
Windows - Chrome 60, Firefox 54, Internet Explorer 11, Microsoft Edge 38
Linux - Chrome 60, Firefox 54
iOS 10.3.3 - Safari (Latest Version), Chrome 60

Windows - IE11 - JAWS
Windows - Firefox 54 - NVDA
